### PR TITLE
Decrease priority

### DIFF
--- a/admin/class.settings-api.php
+++ b/admin/class.settings-api.php
@@ -80,14 +80,14 @@ if ( ! class_exists('cnSettingsAPI') )
 		public function init()
 		{
 			// Register the settings tabs.
-			add_action( 'admin_init' , array( &$this , 'registerTabs' ), .1 );
+			add_action( 'admin_init' , array( &$this , 'registerTabs' ), 2 );
 
 			// Register the settings sections.
-			add_action( 'admin_init' , array( &$this , 'registerSections' ), .1 );
+			add_action( 'admin_init' , array( &$this , 'registerSections' ), 2 );
 
 			// Register the sections fields.
-			add_action( 'admin_init' , array( &$this , 'addSettingsField' ), .1 );
-			add_action( 'init' , array( &$this , 'registerFields' ), .1 );
+			add_action( 'admin_init' , array( &$this , 'addSettingsField' ), 2 );
+			add_action( 'init' , array( &$this , 'registerFields' ), 2 );
 		}
 
 		/**


### PR DESCRIPTION
Decreases priority just enough so custom post types can registered before the plugin, allowing for `get_post_types` to correctly return all CPTs instead of just built in ones.